### PR TITLE
Adjust pinning for `ooxml_docprops` package.

### DIFF
--- a/release/opengever/2.8
+++ b/release/opengever/2.8
@@ -57,6 +57,7 @@ ftw.zipexport = 1.2.1
 importlib = 1.0.2
 imsvdex = 1.0
 mr.developer = 1.22
+ooxml-docprops = 1.0.0
 ooxml_docprops = 1.0.0
 opengever.async = 1.1
 opengever.core = 3.3

--- a/release/opengever/2.9
+++ b/release/opengever/2.9
@@ -57,6 +57,7 @@ ftw.zipexport = 1.2.1
 importlib = 1.0.2
 imsvdex = 1.0
 mr.developer = 1.22
+ooxml-docprops = 1.0.0
 ooxml_docprops = 1.0.0
 opengever.async = 1.2
 opengever.core = 3.4.1

--- a/release/opengever/2.9.1
+++ b/release/opengever/2.9.1
@@ -55,6 +55,7 @@ ftw.zipexport = 1.2.1
 importlib = 1.0.2
 imsvdex = 1.0
 mr.developer = 1.22
+ooxml-docprops = 1.0.0
 ooxml_docprops = 1.0.0
 opengever.async = 1.2
 opengever.core = 3.4.1

--- a/release/opengever/3.0
+++ b/release/opengever/3.0
@@ -56,6 +56,7 @@ ftw.zipexport = 1.2.1
 importlib = 1.0.2
 imsvdex = 1.0
 mr.developer = 1.22
+ooxml-docprops = 1.1.0
 ooxml_docprops = 1.1.0
 opengever.async = 1.2
 opengever.core = 4.0.1


### PR DESCRIPTION
Because packages with underscores in names are converted to dashes, we temporarily pin both "version" of names.
To be sure that the pinnings are working correctly.

@lukasgraf as we discussed 
