### PR TITLE
opengever-zug/2.9.1: Bump ftw.tika to 2.0

### DIFF
--- a/release/opengever-zug/2.9.1
+++ b/release/opengever-zug/2.9.1
@@ -9,3 +9,4 @@ extends = http://kgs.4teamwork.ch/release/opengever/2.9.1
 izug.basetheme = 1.4.7
 opengever.zug = 1.8.1
 opengever.zugconfig = 2.2
+ftw.tika = 2.0


### PR DESCRIPTION
Bumps `ftw.tika` to version `2.0` for `opengever-zug/2.9.1`.

@phgross 
