### PR TITLE
opengever-zug/3.0.1: Bump ftw.tika to 2.0

### DIFF
--- a/release/opengever-zug/3.0.1
+++ b/release/opengever-zug/3.0.1
@@ -7,3 +7,4 @@ extends = http://kgs.4teamwork.ch/release/opengever/3.0.1
 [versions]
 opengever.zug = 1.8.1
 opengever.zugconfig = 2.2
+ftw.tika = 2.0


### PR DESCRIPTION
`opengever-zug/3.0.1`: Bump `ftw.tika` to version `2.0`
