### PR TITLE
GEVER Zug: Bumped opengever.zug to newest version

### DIFF
--- a/release/opengever-zug/2.9.2
+++ b/release/opengever-zug/2.9.2
@@ -6,6 +6,6 @@ extends = http://kgs.4teamwork.ch/release/opengever/2.9.2
 
 [versions]
 izug.basetheme = 1.4.7
-opengever.zug = 1.8.3
+opengever.zug = 1.8.4
 opengever.zugconfig = 2.2
 ftw.tika = 2.0.1

--- a/release/opengever-zug/3.0
+++ b/release/opengever-zug/3.0
@@ -5,6 +5,6 @@
 extends = http://kgs.4teamwork.ch/release/opengever/3.0
 
 [versions]
-opengever.zug = 1.8.1
+opengever.zug = 1.8.4
 opengever.zugconfig = 2.2
 ftw.tika = 2.0

--- a/release/opengever-zug/3.0.1
+++ b/release/opengever-zug/3.0.1
@@ -5,6 +5,6 @@
 extends = http://kgs.4teamwork.ch/release/opengever/3.0.1
 
 [versions]
-opengever.zug = 1.8.1
+opengever.zug = 1.8.4
 opengever.zugconfig = 2.2
 ftw.tika = 2.0

--- a/release/opengever-zug/3.0.2
+++ b/release/opengever-zug/3.0.2
@@ -5,5 +5,5 @@
 extends = http://kgs.4teamwork.ch/release/opengever/3.0.2
 
 [versions]
-opengever.zug = 1.8.1
+opengever.zug = 1.8.4
 opengever.zugconfig = 2.2


### PR DESCRIPTION
This release includes newest release `1.8.4` which includes new client `BD.HBA`.

@lukasgraf please have a look ... 
