### PR TITLE
Bump opengever.ai to 1.1.1 in og-ai/3.0.3 KGS.

### DIFF
--- a/release/opengever-ai/3.0.3
+++ b/release/opengever-ai/3.0.3
@@ -5,4 +5,4 @@
 extends = http://kgs.4teamwork.ch/release/opengever/3.0.3
 
 [versions]
-opengever.ai = 1.1.0
+opengever.ai = 1.1.1


### PR DESCRIPTION
`opengever.ai==1.1.1` includes the new repository XLSX as of 2014-01-07.