### PR TITLE
Bump opengever.ai to 1.1.3 in og-ai/3.0.4 KGS.

### DIFF
--- a/release/opengever-ai/3.0.4
+++ b/release/opengever-ai/3.0.4
@@ -5,4 +5,4 @@
 extends = http://kgs.4teamwork.ch/release/opengever/3.0.4
 
 [versions]
-opengever.ai = 1.1.2
+opengever.ai = 1.1.3


### PR DESCRIPTION
opengever.ai `1.1.3` includes the newest repository XLSX.