### PR TITLE
Bump opengever.ai to 1.1.4 in og-ai/3.0.4 KGS.

### DIFF
--- a/release/opengever-ai/3.0.4
+++ b/release/opengever-ai/3.0.4
@@ -5,4 +5,4 @@
 extends = http://kgs.4teamwork.ch/release/opengever/3.0.4
 
 [versions]
-opengever.ai = 1.1.3
+opengever.ai = 1.1.4


### PR DESCRIPTION
Includes fixes for the `repository.xlsx`.