### PR TITLE
Pin zc.buildout for opengever-sg/3.0.2.

### DIFF
--- a/release/opengever-sg/3.0.2
+++ b/release/opengever-sg/3.0.2
@@ -10,3 +10,5 @@ opengever.sg = 1.1.1
 
 netsight.windowsauthplugin = 2.0
 kerberos = 1.1.1
+
+zc.buildout = 1.7.1


### PR DESCRIPTION
(We need at least `1.5` for the `buildout.dumppickedversions` extension to work anyway).

@phgross @deiferni 
