### PR TITLE
Pin dependencies for the most recent netsight.windowsauthplugin from python-gssapi branch

### DIFF
--- a/release/opengever-sg/3.0.2
+++ b/release/opengever-sg/3.0.2
@@ -12,3 +12,10 @@ netsight.windowsauthplugin = 2.0
 kerberos = 1.1.1
 
 zc.buildout = 1.7.1
+
+# Dependencies for netsight.windowsauthplugin:python-gssapi
+cffi = 0.9.2
+pyasn1 = 0.1.7
+pycparser = 2.10
+python-gssapi = 0.6.4
+six = 1.5.0


### PR DESCRIPTION
Pin dependencies for the most recent [`netsight.windowsauthplugin` from `python-gssapi` branch](https://github.com/4teamwork/netsight.windowsauthplugin/tree/python-gssapi)
for `opengever-sg/3.0.2`.
@deiferni 