### PR TITLE
Add ruby-versions section for ruby- and gem-versions.

### DIFF
--- a/release/opengever/3.2
+++ b/release/opengever/3.2
@@ -4,6 +4,10 @@
 [buildout]
 extends = http://dist.plone.org/release/4.2.2/versions.cfg
 
+[ruby-versions]
+ruby = 2.1.5
+sablon = 0.0.8
+
 [versions]
 alembic = 0.7.4
 apachelog = 1.1


### PR DESCRIPTION
Opengever 3.2 integrates [sablon](https://github.com/senny/sablon) for which we also need version pinnings.