### PR TITLE
Update opengever 3.2 to plone 4.2.3.

### DIFF
--- a/release/opengever/3.2
+++ b/release/opengever/3.2
@@ -2,7 +2,7 @@
 # The latest version can be found at http://kgs.4teamwork.ch/release/opengever/3.2
 
 [buildout]
-extends = http://dist.plone.org/release/4.2.2/versions.cfg
+extends = http://dist.plone.org/release/4.2.3/versions.cfg
 
 [ruby-versions]
 ruby = 2.1.5


### PR DESCRIPTION
That way it is no longer necessary to include
`Products.PloneHotfix20121106` which conflicts with
`plone.protect >= 2.0`.