### PR TITLE
Bump opengever.sg to 1.1.3 for opengever-sg/3.0.5.

### DIFF
--- a/release/opengever-sg/3.0.5
+++ b/release/opengever-sg/3.0.5
@@ -6,7 +6,7 @@ extends = http://kgs.4teamwork.ch/release/opengever/3.0.5
 
 
 [versions]
-opengever.sg = 1.1.2
+opengever.sg = 1.1.3
 
 netsight.windowsauthplugin = 2.0
 kerberos = 1.1.1


### PR DESCRIPTION
Bump `opengever.sg` to `1.1.3` for `opengever-sg/3.0.5`.

`1.1.3` contains the final mapping required for the test migration on TEST.

@phgross