### PR TITLE
Pin ftw.zopemaster = 1.1 for opengever-sg/3.0.5.

### DIFF
--- a/release/opengever-sg/3.0.5
+++ b/release/opengever-sg/3.0.5
@@ -7,6 +7,7 @@ extends = http://kgs.4teamwork.ch/release/opengever/3.0.5
 
 [versions]
 opengever.sg = 1.1.3
+ftw.zopemaster = 1.1
 
 netsight.windowsauthplugin = 2.0
 kerberos = 1.1.1


### PR DESCRIPTION
Pin `ftw.zopemaster = 1.1` for`opengever-sg/3.0.5`.

The `1.1` release is required in order to be able to disable SSL certificate verification.