### PR TITLE
Pin plone.recipe.zope2instance = 4.2.16 for opengever/3.3.

### DIFF
--- a/release/opengever/3.3
+++ b/release/opengever/3.3
@@ -98,6 +98,7 @@ plone.keyring = 3.0.0
 plone.principalsource = 1.0b1
 plone.protect = 3.0.1
 plone.recipe.precompiler = 0.6
+plone.recipe.zope2instance = 4.2.16
 plonegov.pdflatex = 1.5.1
 plonegov.recipe.pdflatex = 0.5
 plonetheme.teamraum = 3.2.2


### PR DESCRIPTION
This makes sure we're using a version of the recipe that supports using `zcml-additional += ...` assignments (see https://github.com/plone/plone.recipe.zope2instance/pull/13).

@phgross 