### PR TITLE
Bump opengever.sg to 1.1.4 for opengever-sg/3.0.5.

### DIFF
--- a/release/opengever-sg/3.0.5
+++ b/release/opengever-sg/3.0.5
@@ -6,7 +6,7 @@ extends = http://kgs.4teamwork.ch/release/opengever/3.0.5
 
 
 [versions]
-opengever.sg = 1.1.3
+opengever.sg = 1.1.4
 ftw.zopemaster = 1.1
 
 netsight.windowsauthplugin = 2.0


### PR DESCRIPTION
Bump `opengever.sg` to `1.1.4` for `opengever-sg/3.0.5`.

This includes the latest principal migration mapping for PROD.

@phgross 