### PR TITLE
Also pin meld3 for older opengever KGSs (required by supervisor).

### DIFF
--- a/release/opengever/3.0
+++ b/release/opengever/3.0
@@ -58,6 +58,7 @@ ftw.zopemaster = 1.0.0
 importlib = 1.0.2
 imsvdex = 1.0
 Mako = 1.0.0
+meld3 = 1.0.0
 mr.developer = 1.22
 MySQL-python = 1.2.3
 ooxml-docprops = 1.1.0

--- a/release/opengever/3.0.1
+++ b/release/opengever/3.0.1
@@ -58,6 +58,7 @@ ftw.zopemaster = 1.0.0
 importlib = 1.0.2
 imsvdex = 1.0
 Mako = 1.0.0
+meld3 = 1.0.0
 mr.developer = 1.22
 MySQL-python = 1.2.3
 ooxml-docprops = 1.1.0

--- a/release/opengever/3.0.2
+++ b/release/opengever/3.0.2
@@ -63,6 +63,7 @@ importlib = 1.0.2
 imsvdex = 1.0
 Mako = 1.0.0
 MarkupSafe = 0.23
+meld3 = 1.0.0
 mr.developer = 1.22
 MySQL-python = 1.2.3
 ooxml-docprops = 1.1.0

--- a/release/opengever/3.0.3
+++ b/release/opengever/3.0.3
@@ -63,6 +63,7 @@ importlib = 1.0.2
 imsvdex = 1.0
 Mako = 1.0.0
 MarkupSafe = 0.23
+meld3 = 1.0.0
 mr.developer = 1.22
 MySQL-python = 1.2.3
 ooxml-docprops = 1.1.0

--- a/release/opengever/3.0.4
+++ b/release/opengever/3.0.4
@@ -63,6 +63,7 @@ importlib = 1.0.2
 imsvdex = 1.0
 Mako = 1.0.0
 MarkupSafe = 0.23
+meld3 = 1.0.0
 mr.developer = 1.22
 MySQL-python = 1.2.3
 ooxml-docprops = 1.1.0

--- a/release/opengever/3.0.5
+++ b/release/opengever/3.0.5
@@ -63,6 +63,7 @@ importlib = 1.0.2
 imsvdex = 1.0
 Mako = 1.0.0
 MarkupSafe = 0.23
+meld3 = 1.0.0
 mr.developer = 1.22
 MySQL-python = 1.2.3
 ooxml-docprops = 1.1.0

--- a/release/opengever/3.1
+++ b/release/opengever/3.1
@@ -63,6 +63,7 @@ importlib = 1.0.2
 imsvdex = 1.0
 Mako = 1.0.0
 MarkupSafe = 0.23
+meld3 = 1.0.0
 mr.developer = 1.22
 MySQL-python = 1.2.3
 ooxml-docprops = 1.1.0


### PR DESCRIPTION
`meld3` is a dependency of supervisor that was previously unpinned. In order to be able to buildout older opengever `3.x` buildouts with `allow-picked-versions = False`, `meld3` needs to be pinned for those.

@phgross 