### PR TITLE
Pin ftw.usermigration = 1.1 for opengever-sg/3.0.5.

### DIFF
--- a/release/opengever-sg/3.0.5
+++ b/release/opengever-sg/3.0.5
@@ -8,6 +8,7 @@ extends = http://kgs.4teamwork.ch/release/opengever/3.0.5
 [versions]
 opengever.sg = 1.1.4
 ftw.zopemaster = 1.1
+ftw.usermigration = 1.1
 
 netsight.windowsauthplugin = 2.0
 kerberos = 1.1.1


### PR DESCRIPTION
We've been using `ftw.usermigration` from source for the actual migration in production in order to be able to react quickly to unexpected issues.

Now that the migration is done, I've created an `1.1` release which we should use.

@phgross 