### PR TITLE
Bump opengever.sg to 1.1.5 for opengever-sg/3.0.5 KGS.

### DIFF
--- a/release/opengever-sg/3.0.5
+++ b/release/opengever-sg/3.0.5
@@ -6,7 +6,7 @@ extends = http://kgs.4teamwork.ch/release/opengever/3.0.5
 
 
 [versions]
-opengever.sg = 1.1.4
+opengever.sg = 1.1.5
 ftw.zopemaster = 1.1
 ftw.usermigration = 1.1
 


### PR DESCRIPTION
Bump `opengever.sg` to `1.1.5` for `opengever-sg/3.0.5` KGS.