### PR TITLE
Introduce github-private-cloneurl.

### DIFF
--- a/sources/sources.cfg
+++ b/sources/sources.cfg
@@ -3,7 +3,7 @@
 
 [buildout]
 extends = http://plonesource.org/sources.cfg
-github-cloneurl = ${buildout:github-ssh}
+github-private-cloneurl = ${buildout:github-ssh}
 
 
 [branches]
@@ -98,18 +98,18 @@ teamraum.com = 4teamwork
 
 [sources]
 bern.intranettheme = git git@git.4teamwork.ch:bern/bern.intranettheme.git  branch=${branches:bern.intranettheme}
-bern.web = git ${buildout:github-cloneurl}${forks:bern.web}/bern.web.git pushurl=${buildout:github-pushurl}${forks:bern.web}/bern.web.git branch=${branches:bern.web}
+bern.web = git ${buildout:github-private-cloneurl}${forks:bern.web}/bern.web.git pushurl=${buildout:github-pushurl}${forks:bern.web}/bern.web.git branch=${branches:bern.web}
 bern.webtheme = git git@git.4teamwork.ch:bern/bern.webtheme.git  branch=${branches:bern.webtheme}
-bgbern.theme = git ${buildout:github-cloneurl}${forks:bgbern.theme}/bgbern.theme.git pushurl=${buildout:github-pushurl}${forks:bgbern.theme}/bgbern.theme.git branch=${branches:bgbern.theme}
-bgbern.web = git ${buildout:github-cloneurl}${forks:bgbern.web}/bgbern.web.git pushurl=${buildout:github-pushurl}${forks:bgbern.web}/bgbern.web.git branch=${branches:bgbern.web}
+bgbern.theme = git ${buildout:github-private-cloneurl}${forks:bgbern.theme}/bgbern.theme.git pushurl=${buildout:github-pushurl}${forks:bgbern.theme}/bgbern.theme.git branch=${branches:bgbern.theme}
+bgbern.web = git ${buildout:github-private-cloneurl}${forks:bgbern.web}/bgbern.web.git pushurl=${buildout:github-pushurl}${forks:bgbern.web}/bgbern.web.git branch=${branches:bgbern.web}
 cipra.migration = git git@git.4teamwork.ch:cipra/cipra.migration.git  branch=${branches:cipra.migration}
 cipra.theme = git git@git.4teamwork.ch:cipra/cipra.theme.git  branch=${branches:cipra.theme}
-cipra.web = git ${buildout:github-cloneurl}${forks:cipra.web}/cipra.web.git pushurl=${buildout:github-pushurl}${forks:cipra.web}/cipra.web.git branch=${branches:cipra.web}
-eGov = git ${buildout:github-cloneurl}${forks:eGov}/eGov.git pushurl=${buildout:github-pushurl}${forks:eGov}/eGov.git branch=${branches:eGov}
+cipra.web = git ${buildout:github-private-cloneurl}${forks:cipra.web}/cipra.web.git pushurl=${buildout:github-pushurl}${forks:cipra.web}/cipra.web.git branch=${branches:cipra.web}
+eGov = git ${buildout:github-private-cloneurl}${forks:eGov}/eGov.git pushurl=${buildout:github-pushurl}${forks:eGov}/eGov.git branch=${branches:eGov}
 edubs.migration = git git@git.4teamwork.ch:bs/edubs.migration.git  branch=${branches:edubs.migration}
 edubs.policy = git git@git.4teamwork.ch:bs/edubs.policy.git  branch=${branches:edubs.policy}
 egov.classification = git git@git.4teamwork.ch:egov/egov.classification.git  branch=${branches:egov.classification}
-egov.contactdirectory = git ${buildout:github-cloneurl}${forks:egov.contactdirectory}/egov.contactdirectory.git pushurl=${buildout:github-pushurl}${forks:egov.contactdirectory}/egov.contactdirectory.git branch=${branches:egov.contactdirectory}
+egov.contactdirectory = git ${buildout:github-private-cloneurl}${forks:egov.contactdirectory}/egov.contactdirectory.git pushurl=${buildout:github-pushurl}${forks:egov.contactdirectory}/egov.contactdirectory.git branch=${branches:egov.contactdirectory}
 egov.contentpage = git git@git.4teamwork.ch:egov/egov.contentpage.git  branch=${branches:egov.contentpage}
 egov.izugtheme = git git@git.4teamwork.ch:egov/egov.izugtheme.git  branch=${branches:egov.izugtheme}
 egov.jsonimport = git git@git.4teamwork.ch:egov/egov.jsonimport.git  branch=${branches:egov.jsonimport}
@@ -120,35 +120,35 @@ egov.topics = git git@git.4teamwork.ch:egov/egov.topics.git  branch=${branches:e
 egov.upgrade = git git@git.4teamwork.ch:egov/egov.upgrade.git  branch=${branches:egov.upgrade}
 egov.workflows = git git@git.4teamwork.ch:egov/egov.workflows.git  branch=${branches:egov.workflows}
 ftw.mimetypes = git git@git.4teamwork.ch:ftw/ftw.mimetypes.git  branch=${branches:ftw.mimetypes}
-ftw.myworkspace = git ${buildout:github-cloneurl}${forks:ftw.myworkspace}/ftw.myworkspace.git pushurl=${buildout:github-pushurl}${forks:ftw.myworkspace}/ftw.myworkspace.git branch=${branches:ftw.myworkspace}
+ftw.myworkspace = git ${buildout:github-private-cloneurl}${forks:ftw.myworkspace}/ftw.myworkspace.git pushurl=${buildout:github-pushurl}${forks:ftw.myworkspace}/ftw.myworkspace.git branch=${branches:ftw.myworkspace}
 ftw.portletview = git git@git.4teamwork.ch:ftw/ftw.portletview.git  branch=${branches:ftw.portletview}
 ftw.zopemaster = git git@git.4teamwork.ch:ftw/ftw.zopemaster.git  branch=${branches:ftw.zopemaster}
 ftwshop.adminpay = git git@git.4teamwork.ch:ftw/ftwshop.adminpay.git  branch=${branches:ftwshop.adminpay}
 helbling.alumni = git git@git.4teamwork.ch:helbling/helbling.alumni.git  branch=${branches:helbling.alumni}
-helbling.theme = git ${buildout:github-cloneurl}${forks:helbling.theme}/helbling.theme.git pushurl=${buildout:github-pushurl}${forks:helbling.theme}/helbling.theme.git branch=${branches:helbling.theme}
-helbling.web = git ${buildout:github-cloneurl}${forks:helbling.web}/helbling.web.git pushurl=${buildout:github-pushurl}${forks:helbling.web}/helbling.web.git branch=${branches:helbling.web}
+helbling.theme = git ${buildout:github-private-cloneurl}${forks:helbling.theme}/helbling.theme.git pushurl=${buildout:github-pushurl}${forks:helbling.theme}/helbling.theme.git branch=${branches:helbling.theme}
+helbling.web = git ${buildout:github-private-cloneurl}${forks:helbling.web}/helbling.web.git pushurl=${buildout:github-pushurl}${forks:helbling.web}/helbling.web.git branch=${branches:helbling.web}
 ivbe.theme = git git@git.4teamwork.ch:ivbe/ivbe.theme.git  branch=${branches:ivbe.theme}
-izug.latex = git ${buildout:github-cloneurl}${forks:izug.latex}/izug.latex.git pushurl=${buildout:github-pushurl}${forks:izug.latex}/izug.latex.git branch=${branches:izug.latex}
-izug.onegov = git ${buildout:github-cloneurl}${forks:izug.onegov}/izug.onegov.git pushurl=${buildout:github-pushurl}${forks:izug.onegov}/izug.onegov.git branch=${branches:izug.onegov}
-izug.organisation = git ${buildout:github-cloneurl}${forks:izug.organisation}/izug.organisation.git pushurl=${buildout:github-pushurl}${forks:izug.organisation}/izug.organisation.git branch=${branches:izug.organisation}
+izug.latex = git ${buildout:github-private-cloneurl}${forks:izug.latex}/izug.latex.git pushurl=${buildout:github-pushurl}${forks:izug.latex}/izug.latex.git branch=${branches:izug.latex}
+izug.onegov = git ${buildout:github-private-cloneurl}${forks:izug.onegov}/izug.onegov.git pushurl=${buildout:github-pushurl}${forks:izug.onegov}/izug.onegov.git branch=${branches:izug.onegov}
+izug.organisation = git ${buildout:github-private-cloneurl}${forks:izug.organisation}/izug.organisation.git pushurl=${buildout:github-pushurl}${forks:izug.organisation}/izug.organisation.git branch=${branches:izug.organisation}
 izug.refegovservice = git git@git.4teamwork.ch:izug/izug.refegovservice.git  branch=${branches:izug.refegovservice}
-my.teamraum = git ${buildout:github-cloneurl}${forks:my.teamraum}/my.teamraum.git pushurl=${buildout:github-pushurl}${forks:my.teamraum}/my.teamraum.git branch=${branches:my.teamraum}
-ooxml_docprops = git ${buildout:github-cloneurl}${forks:ooxml_docprops}/ooxml_docprops.git pushurl=${buildout:github-pushurl}${forks:ooxml_docprops}/ooxml_docprops.git branch=${branches:ooxml_docprops}
-opengever.ai = git ${buildout:github-cloneurl}${forks:opengever.ai}/opengever.ai.git pushurl=${buildout:github-pushurl}${forks:opengever.ai}/opengever.ai.git branch=${branches:opengever.ai}
-opengever.async = git ${buildout:github-cloneurl}${forks:opengever.async}/opengever.async.git pushurl=${buildout:github-pushurl}${forks:opengever.async}/opengever.async.git branch=${branches:opengever.async}
-opengever.bs = git ${buildout:github-cloneurl}${forks:opengever.bs}/opengever.bs.git pushurl=${buildout:github-pushurl}${forks:opengever.bs}/opengever.bs.git branch=${branches:opengever.bs}
-opengever.core = git ${buildout:github-cloneurl}${forks:opengever.core}/opengever.core.git pushurl=${buildout:github-pushurl}${forks:opengever.core}/opengever.core.git branch=${branches:opengever.core}
-opengever.demo = git ${buildout:github-cloneurl}${forks:opengever.demo}/opengever.demo.git pushurl=${buildout:github-pushurl}${forks:opengever.demo}/opengever.demo.git branch=${branches:opengever.demo}
+my.teamraum = git ${buildout:github-private-cloneurl}${forks:my.teamraum}/my.teamraum.git pushurl=${buildout:github-pushurl}${forks:my.teamraum}/my.teamraum.git branch=${branches:my.teamraum}
+ooxml_docprops = git ${buildout:github-private-cloneurl}${forks:ooxml_docprops}/ooxml_docprops.git pushurl=${buildout:github-pushurl}${forks:ooxml_docprops}/ooxml_docprops.git branch=${branches:ooxml_docprops}
+opengever.ai = git ${buildout:github-private-cloneurl}${forks:opengever.ai}/opengever.ai.git pushurl=${buildout:github-pushurl}${forks:opengever.ai}/opengever.ai.git branch=${branches:opengever.ai}
+opengever.async = git ${buildout:github-private-cloneurl}${forks:opengever.async}/opengever.async.git pushurl=${buildout:github-pushurl}${forks:opengever.async}/opengever.async.git branch=${branches:opengever.async}
+opengever.bs = git ${buildout:github-private-cloneurl}${forks:opengever.bs}/opengever.bs.git pushurl=${buildout:github-pushurl}${forks:opengever.bs}/opengever.bs.git branch=${branches:opengever.bs}
+opengever.core = git ${buildout:github-private-cloneurl}${forks:opengever.core}/opengever.core.git pushurl=${buildout:github-pushurl}${forks:opengever.core}/opengever.core.git branch=${branches:opengever.core}
+opengever.demo = git ${buildout:github-private-cloneurl}${forks:opengever.demo}/opengever.demo.git pushurl=${buildout:github-pushurl}${forks:opengever.demo}/opengever.demo.git branch=${branches:opengever.demo}
 opengever.docucomposer = git git@git.4teamwork.ch:opengever/opengever.docucomposer.git  branch=${branches:opengever.docucomposer}
-opengever.docugate = git ${buildout:github-cloneurl}${forks:opengever.docugate}/opengever.docugate.git pushurl=${buildout:github-pushurl}${forks:opengever.docugate}/opengever.docugate.git branch=${branches:opengever.docugate}
-opengever.edk = git ${buildout:github-cloneurl}${forks:opengever.edk}/opengever.edk.git pushurl=${buildout:github-pushurl}${forks:opengever.edk}/opengever.edk.git branch=${branches:opengever.edk}
-opengever.maintenance = git ${buildout:github-cloneurl}${forks:opengever.maintenance}/opengever.maintenance.git pushurl=${buildout:github-pushurl}${forks:opengever.maintenance}/opengever.maintenance.git branch=${branches:opengever.maintenance}
-opengever.pdfconverter = git ${buildout:github-cloneurl}${forks:opengever.pdfconverter}/opengever.pdfconverter.git pushurl=${buildout:github-pushurl}${forks:opengever.pdfconverter}/opengever.pdfconverter.git branch=${branches:opengever.pdfconverter}
-opengever.phbern = git ${buildout:github-cloneurl}${forks:opengever.phbern}/opengever.phbern.git pushurl=${buildout:github-pushurl}${forks:opengever.phbern}/opengever.phbern.git branch=${branches:opengever.phbern}
-opengever.phvs = git ${buildout:github-cloneurl}${forks:opengever.phvs}/opengever.phvs.git pushurl=${buildout:github-pushurl}${forks:opengever.phvs}/opengever.phvs.git branch=${branches:opengever.phvs}
-opengever.sg = git ${buildout:github-cloneurl}${forks:opengever.sg}/opengever.sg.git pushurl=${buildout:github-pushurl}${forks:opengever.sg}/opengever.sg.git branch=${branches:opengever.sg}
-opengever.zug = git ${buildout:github-cloneurl}${forks:opengever.zug}/opengever.zug.git pushurl=${buildout:github-pushurl}${forks:opengever.zug}/opengever.zug.git branch=${branches:opengever.zug}
-plonetheme.teamraum = git ${buildout:github-cloneurl}${forks:plonetheme.teamraum}/plonetheme.teamraum.git pushurl=${buildout:github-pushurl}${forks:plonetheme.teamraum}/plonetheme.teamraum.git branch=${branches:plonetheme.teamraum}
+opengever.docugate = git ${buildout:github-private-cloneurl}${forks:opengever.docugate}/opengever.docugate.git pushurl=${buildout:github-pushurl}${forks:opengever.docugate}/opengever.docugate.git branch=${branches:opengever.docugate}
+opengever.edk = git ${buildout:github-private-cloneurl}${forks:opengever.edk}/opengever.edk.git pushurl=${buildout:github-pushurl}${forks:opengever.edk}/opengever.edk.git branch=${branches:opengever.edk}
+opengever.maintenance = git ${buildout:github-private-cloneurl}${forks:opengever.maintenance}/opengever.maintenance.git pushurl=${buildout:github-pushurl}${forks:opengever.maintenance}/opengever.maintenance.git branch=${branches:opengever.maintenance}
+opengever.pdfconverter = git ${buildout:github-private-cloneurl}${forks:opengever.pdfconverter}/opengever.pdfconverter.git pushurl=${buildout:github-pushurl}${forks:opengever.pdfconverter}/opengever.pdfconverter.git branch=${branches:opengever.pdfconverter}
+opengever.phbern = git ${buildout:github-private-cloneurl}${forks:opengever.phbern}/opengever.phbern.git pushurl=${buildout:github-pushurl}${forks:opengever.phbern}/opengever.phbern.git branch=${branches:opengever.phbern}
+opengever.phvs = git ${buildout:github-private-cloneurl}${forks:opengever.phvs}/opengever.phvs.git pushurl=${buildout:github-pushurl}${forks:opengever.phvs}/opengever.phvs.git branch=${branches:opengever.phvs}
+opengever.sg = git ${buildout:github-private-cloneurl}${forks:opengever.sg}/opengever.sg.git pushurl=${buildout:github-pushurl}${forks:opengever.sg}/opengever.sg.git branch=${branches:opengever.sg}
+opengever.zug = git ${buildout:github-private-cloneurl}${forks:opengever.zug}/opengever.zug.git pushurl=${buildout:github-pushurl}${forks:opengever.zug}/opengever.zug.git branch=${branches:opengever.zug}
+plonetheme.teamraum = git ${buildout:github-private-cloneurl}${forks:plonetheme.teamraum}/plonetheme.teamraum.git pushurl=${buildout:github-pushurl}${forks:plonetheme.teamraum}/plonetheme.teamraum.git branch=${branches:plonetheme.teamraum}
 psi.policy = git git@git.4teamwork.ch:teamraum/psi.policy.git  branch=${branches:psi.policy}
-teamraum.com = git ${buildout:github-cloneurl}${forks:teamraum.com}/teamraum.com.git pushurl=${buildout:github-pushurl}${forks:teamraum.com}/teamraum.com.git branch=${branches:teamraum.com}
+teamraum.com = git ${buildout:github-private-cloneurl}${forks:teamraum.com}/teamraum.com.git pushurl=${buildout:github-pushurl}${forks:teamraum.com}/teamraum.com.git branch=${branches:teamraum.com}
 transmogrify.sqlinserter = git git@git.4teamwork.ch:collective/transmogrify.sqlinserter.git  branch=${branches:transmogrify.sqlinserter}

--- a/sources/update.py
+++ b/sources/update.py
@@ -13,7 +13,7 @@ PREFIX = '''# DO NOT MODIFY
 
 [buildout]
 extends = http://plonesource.org/sources.cfg
-github-cloneurl = ${buildout:github-ssh}
+github-private-cloneurl = ${buildout:github-ssh}
 '''
 
 
@@ -53,7 +53,7 @@ def write_sources(repos, output):
 
     for name in repos['github_private']:
         output['sources'][name] = \
-            'git ${buildout:github-cloneurl}' \
+            'git ${buildout:github-private-cloneurl}' \
             '${forks:%(name)s}/%(name)s.git' \
             ' pushurl=${buildout:github-pushurl}' \
             '${forks:%(name)s}/%(name)s.git' \


### PR DESCRIPTION
This reverts 2940de12, which undermines the cloneurl functionality of plonesource.org.
Public repositories should **always** be cloned with https, not ssh.
There are servers which disallow ssh connections to github.

This change introduces a ``github-private-cloneurl``, which defaults to ``ssh`` and is used for private repositories (added by the kgs sources) without changing the cloneurl for public repositories.

--

2940de12 was:

> sources.cfg: always clone with https.
>
> The problem is that the kgs' sources.cfg includes private repositories, now using the cloneurl option.
> Private repositories require authentication (not ssh-key) when cloned using https.
> plonesource.org always uses https for cloning, but that only works for public repositories.
> Therefore we change the cloneurl to ssh for all repositories.

/cc @phgross @maethu 