### PR TITLE
GEVER: update pinnings for Plone 4.3 and Dexterity 2 update.

### DIFF
--- a/release/opengever/develop
+++ b/release/opengever/develop
@@ -1,7 +1,8 @@
-# Known good set for current devlopment version of opengever
+# Known good set for opengever
+# The latest version can be found at http://kgs.4teamwork.ch/release/opengever/3.3
 
 [buildout]
-extends = http://dist.plone.org/release/4.2.3/versions.cfg
+extends = http://dist.plone.org/release/4.3.2/versions.cfg
 
 [ruby-versions]
 ruby = 2.1.5
@@ -17,12 +18,11 @@ blessed = 1.9.5
 collective.autopermission = 1.0b2
 collective.blueprint.jsonmigrator = 0.1.1
 collective.blueprint.usersandgroups = 0.1.3
-collective.dexteritytextindexer = 1.5
+collective.dexteritytextindexer = 2.0.1
 collective.elephantvocabulary = 0.2.4
 collective.jqcookie = 1.1.0
 collective.js.extjs = 1.2
 collective.js.jqsmartTruncation = 1.0
-collective.js.jqueryui = 1.8.13.1
 collective.js.throttledebounce = 1.1
 collective.mtrsetup = 1.2
 collective.quickupload = 1.6.5
@@ -31,7 +31,7 @@ collective.recipe.filestorage = 0.6
 collective.recipe.scriptgen = 0.2
 collective.recipe.shelloutput = 0.1
 collective.recipe.supervisor = 0.17
-collective.transmogrifier = 1.3
+collective.transmogrifier = 1.4
 collective.usernamelogger = 1.2
 collective.vdexvocabulary = 0.1.1
 cssselect = 0.9.1
@@ -46,30 +46,30 @@ elementtreewriter = 1.1
 errbit = 1.1.4
 ftw.builder = 1.6.0
 ftw.contentmenu = 2.4.0
-ftw.dashboard.dragndrop = 1.5.4
-ftw.dashboard.portlets.favourites = 3.1.2
+ftw.dashboard.dragndrop = 1.5.5
+ftw.dashboard.portlets.favourites = 3.3.0
 ftw.dashboard.portlets.postit = 1.3.4
-ftw.dashboard.portlets.recentlymodified = 1.2.8
+ftw.dashboard.portlets.recentlymodified = 1.3.0
 ftw.datepicker = 1.0.4
 ftw.dictstorage = 1.2
-ftw.footer = 1.0.0
+ftw.footer = 1.0.2
 ftw.inflator = 1.5
-ftw.journal = 1.2.6
+ftw.journal = 1.2.8
 ftw.js.statusmessages = 1.0
 ftw.mail = 2.3.1
-ftw.mobilenavigation = 1.3.0
+ftw.mobilenavigation = 1.4.1
 ftw.maintenanceserver = 1.0.2
-ftw.pdfgenerator = 1.2.4
+ftw.pdfgenerator = 1.3.7
 ftw.profilehook = 1.0.0
 ftw.recipe.deployment = 1.1.1
 ftw.tabbedview = 3.4.0
 ftw.table = 1.15.2
 ftw.tika = 2.0.1
-ftw.tooltip = 1.1
+ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
-ftw.upgrade = 1.14.2
-ftw.zipexport = 1.2.1
-ftw.zopemaster = 1.0.0
+ftw.upgrade = 1.14.5
+ftw.zipexport = 1.3.0
+ftw.zopemaster = 1.1.0
 hexagonit.recipe.download = 1.7
 importlib = 1.0.2
 imsvdex = 1.0
@@ -94,9 +94,7 @@ path.py = 7.2
 Pillow = 2.6.1
 plone.api = 1.2.1
 plone.app.transmogrifier = 1.2
-plone.app.versioningbehavior = 1.1.4
 plone.formwidget.autocomplete = 1.2.1-20150330
-plone.formwidget.contenttree = 1.0.7
 plone.keyring = 3.0.0
 plone.principalsource = 1.0b1
 plone.protect = 3.0.1


### PR DESCRIPTION
See https://github.com/4teamwork/opengever.core/pull/982 for more information.