### PR TITLE
Bump bern.web version.

### DIFF
--- a/release/bern/1.1.9
+++ b/release/bern/1.1.9
@@ -1,0 +1,62 @@
+# Known good set for bern
+# The latest version can be found at http://kgs.4teamwork.ch/release/bern/develop-latest
+
+[versions]
+
+# http://kgs.4teamwork.ch/release/bern/1.1.9
+bern.web = 1.3.8
+
+# http://kgs.4teamwork.ch/release/bern/1.1.6
+ftw.file = 1.8.2
+
+# http://kgs.4teamwork.ch/release/bern/1.1.5
+ftw.publisher.sender = 2.2.1
+
+# http://kgs.4teamwork.ch/release/bern/1.1.3
+bern.webtheme = 1.1.3
+
+# http://kgs.4teamwork.ch/release/bern/1.1.1
+ftw.upgrade = 1.7
+ftw.solr = 1.3
+
+# http://kgs.4teamwork.ch/release/bern/1.0.1
+ftw.contentpage = 1.5.3
+ftw.publisher.core = 2.3.3
+
+# http://kgs.4teamwork.ch/release/bern/1.0
+ftw.contenttemplates = 1.0
+Products.LinguaPlone = 4.1.3
+collective.editmodeswitcher = 1.0.1
+ftw.inflator = 1.1.2
+requests = 1.2.3
+collective.js.showmore = 1.0a4
+collective.indexing = 2.0b1
+simplelayout.portlet.dropzone = 1.2.2
+ftw.billboard = 1.2.3
+ftw.poodle = 1.3.3
+ftw.task = 2.4.4
+izug.ticketbox = 4.5.4
+collective.deletepermission = 1.1.1
+errbit = 1.1.2
+xmlbuilder = 1.0
+ftw.dashboard.portlets.postit = 1.3.4
+egov.classification = 1.0.3
+ftw.meeting = 1.4.3
+ftw.workspace = 1.7.0
+ftw.lawgiver = 1.2
+ftw.contentmenu = 2.2.2
+ftw.publisher.receiver = 2.0.1
+egov.workflows = 1.2
+egov.contactdirectory = 1.5.4
+eGov = 4.0.2
+Products.ClockServer = 0.2-Zope2.9dev
+
+# Solr recipe pinnings
+collective.recipe.solrinstance = 5.0.1
+Genshi = 0.6
+gocept.download = 0.9.5
+hexagonit.recipe.download = 1.7
+
+# Testing
+ftw.builder = 1.1.0
+ftw.testing = 1.5.0

--- a/release/bern/develop-latest
+++ b/release/bern/develop-latest
@@ -2,7 +2,7 @@
 # The latest version can be found at http://kgs.4teamwork.ch/release/bern/1.1.6
 
 [buildout]
-extends = http://kgs.4teamwork.ch/release/bern/1.1.8
+extends = http://kgs.4teamwork.ch/release/bern/1.1.9
 
 [versions]
 bern.web =


### PR DESCRIPTION
See https://extranet.4teamwork.ch/support/bern.ch/tracker-www-bern.ch/685/ for more information.