### PR TITLE
gever: add collective.warmup pinning.

### DIFF
--- a/release/opengever/develop
+++ b/release/opengever/develop
@@ -47,6 +47,7 @@ collective.recipe.supervisor = 0.17
 collective.transmogrifier = 1.5
 collective.usernamelogger = 1.3
 collective.vdexvocabulary = 0.2.1
+collective.warmup = 1.1
 collective.z3cform.datagridfield = 1.1
 cssselect = 0.9.1
 cssutils = 1.0


### PR DESCRIPTION
Add `collective.warmup` pinning for when [Warmup](https://github.com/4teamwork/ftw-buildouts#warmup) is used.
Currently it is not used in gever, but with this pinning one may just extend the default config:
```ini
[buildout]
extends =
    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/warmup.cfg
```
