### PR TITLE
gever: include hotfixes in KGS pinnings.

### DIFF
--- a/release/opengever/develop
+++ b/release/opengever/develop
@@ -1,7 +1,9 @@
 # Known good set for opengever (development pinnings).
 
 [buildout]
-extends = http://dist.plone.org/release/4.3.2/versions.cfg
+extends =
+    http://dist.plone.org/release/4.3.2/versions.cfg
+    https://raw.githubusercontent.com/4teamwork/ftw-buildouts/master/hotfixes/4.3.2.cfg
 
 [ruby-versions]
 ruby = 2.1.5


### PR DESCRIPTION
Include the hotfixes in the KGS because in order to have the correct
hotfixes and pinnings for the used Plone versions also in the future.
It also allows us to deploy different GEVER versions with different
Plone's and still having the correct hotfixes.

Closes https://github.com/4teamwork/opengever.core/issues/987