### PR TITLE
Update the rubygems pinnings in release/opengever/develop

### DIFF
--- a/release/opengever/develop
+++ b/release/opengever/develop
@@ -6,9 +6,9 @@ extends =
     http://dist.plone.org/release/4.3.2/versions.cfg
 
 [ruby-versions]
-ruby = 2.1.5
-sablon = 0.0.19
-nokogiri = 1.6.8
+ruby = 2.3.3
+sablon = 0.0.21
+nokogiri = 1.7.2
 
 [versions]
 # buildout / setuptools


### PR DESCRIPTION
This enables one to install opengever on a wider range of operating systems.