### PR TITLE
opengever/develop: Bump p.a.discussion to 2.2.14

### DIFF
--- a/release/opengever/develop
+++ b/release/opengever/develop
@@ -16,6 +16,7 @@ setuptools = 33.1.1
 zc.buildout = 2.5.0
 
 # Plone overrides
+plone.app.discussion = 2.2.12
 plone.keyring = 3.0.1
 plone.locking = 2.0.9
 plone.protect = 3.0.17


### PR DESCRIPTION
**opengever/develop**: Bump p.a.discussion to `2.2.14` in order to make recent `plone.restapi` versions work:

The [`@comments` endpoint](https://github.com/plone/plone.restapi/blob/1275915e6e97d47b5d6bf22b7e776b48e7c1bdd6/src/plone/restapi/services/discussion/conversation.py#L4) needs the `EditCommentForm` from plone/plone.app.discussion@20c2c015 at instance boot time.