### PR TITLE
Update plone.protect to 3.0.20 to address a xss issue.

### DIFF
--- a/release/opengever/develop
+++ b/release/opengever/develop
@@ -16,7 +16,7 @@ setuptools = 33.1.1
 zc.buildout = 2.5.0
 
 # Plone overrides
-plone.protect = 3.0.19
+plone.protect = 3.0.20
 Products.ZCatalog = 3.0.2
 plone.app.versioningbehavior = 1.3.1
 


### PR DESCRIPTION
Please close
https://github.com/4teamwork/opengever.ftw/issues/31

and remove https://github.com/4teamwork/opengever.core/pull/3056, The PR was only there to make sure the built is green. 