### PR TITLE
GEVER: move develop KGS to opengever.core.

### DIFF
--- a/release/opengever/develop
+++ b/release/opengever/develop
@@ -1,4 +1,20 @@
 [buildout]
+
+#
+#             ███████╗████████╗ ██████╗ ██████╗
+#             ██╔════╝╚══██╔══╝██╔═══██╗██╔══██╗
+#             ███████╗   ██║   ██║   ██║██████╔╝
+#             ╚════██║   ██║   ██║   ██║██╔═══╝
+#             ███████║   ██║   ╚██████╔╝██║
+#             ╚══════╝   ╚═╝    ╚═════╝ ╚═╝
+#
+#              DO NOT CHANGE THIS FILE ANYMORE
+#                THE DEVELOP VERSIONS ARE IN
+#               opengever.core's versions.cfg
+#
+#  https://raw.githubusercontent.com/4teamwork/opengever.core/master/versions.cfg
+
+
 extends =
 # Hotfixes must be extended BEFORE the Plone KGS, otherwise you will
 # reset the "instance-eggs" and I have no idea why.


### PR DESCRIPTION
The opengever develop KGS is moved to opengever.core's versions.cfg on the master branch.
Therefore the file release/opengever/develop should no longer be updated.
We are keeping it for a while, so that we do not break older branches relying on it.

See also https://github.com/4teamwork/opengever.core/pull/3104
As discussed in https://github.com/4teamwork/opengever.core/issues/3084