### PR TITLE
opengever: Pin ftw.usermigration for 3.11.4 and later:

### DIFF
--- a/release/opengever/2017.1.0
+++ b/release/opengever/2017.1.0
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/2017.1.1
+++ b/release/opengever/2017.1.1
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/2017.2.0
+++ b/release/opengever/2017.2.0
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/2017.2.1
+++ b/release/opengever/2017.2.1
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/2017.2.2
+++ b/release/opengever/2017.2.2
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/2017.2.3
+++ b/release/opengever/2017.2.3
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/2017.2.4
+++ b/release/opengever/2017.2.4
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/2017.2.5
+++ b/release/opengever/2017.2.5
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/3.11.4
+++ b/release/opengever/3.11.4
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/3.11.5
+++ b/release/opengever/3.11.5
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2

--- a/release/opengever/3.11.6
+++ b/release/opengever/3.11.6
@@ -100,6 +100,7 @@ ftw.tika = 2.0.1
 ftw.tooltip = 1.1.4
 ftw.treeview = 1.2.0
 ftw.upgrade = 2.3.1
+ftw.usermigration = 1.2.0
 ftw.zipexport = 1.4.0
 ftw.zopemaster = 1.1.0
 functools32 = 3.2.3.post2


### PR DESCRIPTION
`ftw.usermigration` has been introduced as a dependency in earlier versions (through a backport), and therefore needs to be pinned for those versions.