### PR TITLE
Copy 4.4 and update collective.quickupload.

### DIFF
--- a/release/teamraum-3rdparty/4.4.1
+++ b/release/teamraum-3rdparty/4.4.1
@@ -1,0 +1,147 @@
+# Known good set for teamraum-3rdparty version 4.4
+# The latest version can be found at http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.4
+
+[versions]
+collective.taskqueue = 0.7.1
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.4
+premailer = 2.9.3
+cssselect = 0.7.1
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.3.1
+argcomplete = 0.8.8
+blessed = 1.9.5
+collective.recipe.scriptgen = 0.2
+collective.recipe.shelloutput = 0.1
+collective.recipe.supervisor = 0.19
+collective.transmogrifier = 1.5
+gspread = 0.2.5
+inflection = 0.3.1
+path.py = 7.3
+plone.app.transmogrifier = 1.3
+plone.recipe.precompiler = 0.6
+supervisor = 3.1.3
+wcwidth = 0.1.4
+Products.TinyMCE = 1.3.10
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.3.0
+collective.quickupload = 1.11.1
+i18ndude = 3.3.5
+plone.formwidget.recaptcha = 1.0b3
+recaptcha-client = 1.0.6
+requests = 2.5.1
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.3.0rc1
+collective.prettydate = 1.2.2
+XlsxWriter = 0.6.4
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.3.0b1
+collective.dexteritytextindexer = 2.0.1
+collective.flowplayer = 4.2.1
+collective.js.jqueryui = 1.10.4
+collective.js.ui.multiselect = 1.0.1
+collective.z3cform.colorpicker = 1.1
+diazo = 1.0.4
+Pillow = 2.3.2
+plone.app.theming = 1.1.1
+plone.formwidget.contenttree = 1.0.7
+plone.principalsource = 1.0
+Products.LDAPUserFolder = 2.27
+Products.PloneFormGen = 1.7.15
+z3c.jbot = 0.7.2
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.2.7
+hexagonit.recipe.download = 1.7
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.2.6
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.2.5
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.2.4
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.2.3
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.2.2
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.2.1
+tarjan = 0.1.2
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.2
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.1.1
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.1
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.1rc3
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.1rc2
+collective.autopermission = 1.0b2
+ua-parser = 0.3.4
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.1rc
+collective.z3cform.wizard = 1.4.8
+Products.DataGridField = 1.9.0
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.0.1
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/4.0
+BeautifulSoup = 3.2.1
+collective.blueprint.jsonmigrator = 0.1.1
+collective.blueprint.usersandgroups = 0.1.3
+collective.geo.contentlocations = 2.5
+collective.geo.geographer = 1.7
+collective.geo.kml = 2.5
+collective.geo.mapwidget = 1.6
+collective.geo.openlayers = 2.5
+collective.geo.settings = 2.5
+collective.jqhistory = 1.0.1
+collective.js.jqsmartTruncation = 1.0
+collective.js.jqtooltip = 1.0
+collective.js.throttledebounce = 1.1
+collective.logbook = 0.6
+collective.portlet.collectionmultiview = 2.1.5
+collective.recipe.filestorage = 0.6
+collective.solr = 3.0
+cssutils = 0.9.9
+dataflake.cache = 1.4
+dataflake.fakeldap = 1.1
+dataflake.ldapconnection = 1.5
+geopy = 0.95
+pygeoif = 0.3.1dev
+kss.core = 1.6.5
+Mako = 0.7.3
+MarkupSafe = 0.15
+plone.formwidget.autocomplete = 1.2.4
+plone.resource = 1.0.2
+Products.AddRemoveWidget = 1.5.0
+Products.AutocompleteWidget = 1.4.0
+Products.LDAPMultiPlugins = 1.14
+Products.Maps = 3.0
+Products.PloneFlashUpload = 1.3
+Products.PloneHotfix20110720 = 1.2
+Products.PloneHotfix20110928 = 1.1
+Products.PloneHotfix20121106 = 1.2
+Products.PloneLDAP = 1.2
+Products.PythonField = 1.1.3
+Products.TALESField = 1.1.3
+Products.TemplateFields = 1.2.5
+Products.Zope-Hotfix-20110622 = 1.0
+Products.Zope-Hotfix-20111024 = 1.0
+python-ldap = 2.3.13
+repoze.xmliter = 0.5
+Shapely = 1.2.17
+StoneageHTML = 0.2.1
+z3c.json = 0.5.4
+z3c.recipe.staticlxml = 0.8
+z3c.widgets.flashupload = 1.0c1
+zc.recipe.cmmi = 1.3.5
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/3.1
+hachoir-core = 1.3.3
+hachoir-metadata = 1.3.3
+hachoir-parser = 1.3.4
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/3.0.2.3
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/3.0.2.2
+
+# http://kgs.4teamwork.ch/release/teamraum-3rdparty/3.0.2


### PR DESCRIPTION
This is to solve https://github.com/4teamwork/oerebk.ticketbox/issues/122

Since collective.quickupload was pinned in 4.4 I created a subversion having a copy of the old one plus the updated version of collective.quickupload.